### PR TITLE
Make pyvisgen dependency optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,12 @@ dependencies = [
   "torch",
   "tqdm",
   "casatools",
-  "pyvisgen@git+https://github.com/radionets-project/pyvisgen.git@main",
+]
+
+[project.optional-dependencies]
+
+pyvisgen = [
+  "pyvisgen"
 ]
 
 [dependency-groups]

--- a/pyvisgrid/core/gridder.py
+++ b/pyvisgrid/core/gridder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -7,7 +9,11 @@ from astropy.constants import c
 from astropy.io import fits
 from casatools.table import table
 from numpy.exceptions import AxisError
-from pyvisgen.simulation import Observation, Visibilities
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyvisgen.simulation import Observation, Visibilities
 
 import pyvisgrid.plotting as plotting
 from pyvisgrid.core.stokes import get_stokes_from_vis_data

--- a/pyvisgrid/core/stokes.py
+++ b/pyvisgrid/core/stokes.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 import numpy as np
-from pyvisgen.simulation import Visibilities
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyvisgen.simulation import Visibilities
 
 
 def get_stokes_from_vis_data(


### PR DESCRIPTION
- Made pyvisgen dependency optional and moved import to `if TYPE_CHECKING` clause to only import it for type hinting

Fixes https://github.com/radionets-project/pyvisgrid/issues/5