### PR TITLE
Change table reading package to casacore, Add times in gridder and uv plotting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,6 @@ jobs:
         if: matrix.environment-type == 'mamba'
         run: micromamba list
 
-      - name: Initialize CASAData
-        run: |
-          mkdir -p ~/.casa/data/
-          python -c "import casatools;"
-
       - name: Tests
         run: |
           pytest -vv --cov --cov-branch --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "toml",
   "torch",
   "tqdm",
-  "casatools",
+  "python-casacore",
 ]
 
 [project.optional-dependencies]

--- a/pyvisgrid/core/gridder.py
+++ b/pyvisgrid/core/gridder.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy.constants import c
 from astropy.io import fits
 from astropy.time import Time
-from casatools.table import table
+from casacore.tables import table
 from numpy.exceptions import AxisError
 from numpy.typing import ArrayLike
 
@@ -109,6 +109,8 @@ class Gridder:
             The u coordinates in meter.
         v_meter : numpy.ndarray
             The v coordinates in meter.
+        times : numpy.ndarray
+            The times (in MJD) at which the visibilities were measured.
         img_size : int
             The size of the image in pixels.
         fov : float
@@ -133,7 +135,7 @@ class Gridder:
         self.u_meter = u_meter
         self.v_meter = v_meter
 
-        self.times = np.tile(times, reps=self.frequencies.size)
+        self.times = Time(np.tile(times, reps=self.frequencies.size), format="mjd")
 
         self.img_size = img_size
 
@@ -458,56 +460,52 @@ class Gridder:
                 f"This measurement set does not exist under the path {path}"
             )
 
-        tab = table(str(path))
+        main_tab = table(str(path), ack=False)
+        spectral_tab = table(str(path / "SPECTRAL_WINDOW"), ack=False)
 
         data_colname = "DATA" if not use_calibrated else "MODEL_DATA"
 
         if desc_id is not None:
-            mask = tab.getcol("DATA_DESC_ID") == desc_id
+            mask = main_tab.getcol("DATA_DESC_ID") == desc_id
             mask_idx = np.argwhere(mask).ravel()
 
-            tab_subset = tab.selectrows(rownrs=mask_idx)
+            main_tab = main_tab.selectrows(rownrs=mask_idx)
 
-            data = tab_subset.getcol(data_colname)
-            uv = tab_subset.getcol("UVW")[:2]
-            times = tab_subset.getcol("TIME")
+            data = main_tab.getcol(data_colname)
+            uv = main_tab.getcol("UVW")[:, :2]
+            times = main_tab.getcol("TIME")
 
-        else:
-            mask = np.ones_like(tab.getcol("DATA_DESC_ID")).astype(bool)
-            data = tab.getcol(data_colname)
-            uv = tab.getcol("UVW")[:2]
-            times = tab.getcol("TIME")
-
-        spectral_tab = table(str(path / "SPECTRAL_WINDOW"))
-
-        if desc_id is not None:
             ref_frequency = spectral_tab.getcell("REF_FREQUENCY", desc_id)
-        else:
-            ref_frequency = spectral_tab.getcell("REF_FREQUENCY", 0)
-
-        if desc_id is not None:
             frequency_offsets = (
                 spectral_tab.getcell("CHAN_FREQ", desc_id) - ref_frequency
             )
+
         else:
+            mask = np.ones_like(main_tab.getcol("DATA_DESC_ID")).astype(bool)
+            data = main_tab.getcol(data_colname)
+            uv = main_tab.getcol("UVW")[:, :2]
+            times = main_tab.getcol("TIME")
+
+            ref_frequency = spectral_tab.getcell("REF_FREQUENCY", 0)
             frequency_offsets = spectral_tab.getcell("CHAN_FREQ", 0) - ref_frequency
 
         if filter_flagged:
-            flag_mask = tab.getcol("FLAG")[..., mask]
-            flag_mask = flag_mask.reshape((-1, flag_mask.shape[-1])).astype(np.uint8)
+            flag_mask = main_tab.getcol("FLAG")
+            flag_mask = flag_mask.reshape((-1, flag_mask.shape[0])).astype(np.uint8)
             flag_mask = np.prod(flag_mask, axis=0)
 
             flag_mask = np.logical_not(flag_mask.astype(bool))
+
         else:
             flag_mask = np.ones(uv.shape[-1]).astype(bool)
 
-        uv = uv[..., flag_mask]
-        data = data[..., flag_mask]
+        uv = uv[flag_mask]
+        data = data[flag_mask]
 
-        u_meter = uv[0]
-        v_meter = uv[1]
+        u_meter = uv[:, 0]
+        v_meter = uv[:, 1]
 
-        stokes_i = data[0] + data[1]
+        stokes_i = data[..., 0] + data[..., 1]
 
         # FIXME: probably some kind of difference in normalization.
         # Factor 0.5 fixes this for now. Has to be investigated.
@@ -516,7 +514,7 @@ class Gridder:
         cls = cls(
             u_meter=u_meter,
             v_meter=v_meter,
-            times=Time(times / 3600 / 24, format="mjd").mjd,
+            times=Time(times[flag_mask] / 3600 / 24, format="mjd").mjd,
             img_size=img_size,
             fov=fov,
             ref_frequency=ref_frequency,
@@ -532,12 +530,28 @@ class Gridder:
 
         Parameters
         ----------
+        gridder : pyvisgrid.Gridder
+            The gridder from which to take the (u,v) coordinates.
         mode : str, optional
             The mode specifying the scale of the (u,v) coordinates.
             This can be either ``wave``, meaning the coordinates are
             plotted in units of the reference wavelength, or ``meter``,
             meaning the (u,v) coordinates will be plotted in meter.
             Default is ``wave``.
+        show_times : bool, optional
+            Whether to show the timestamps of the measured visibilities
+            as a colormap. Default is ``True``.
+        use_relative_time : bool, optional
+            Whether to show the times relative to the timestamp of the
+            first measurement in hours.
+            Default is ``True``.
+        times_cmap: str | matplotlib.colors.Colormap, optional
+            The colormap to be used for the time component of the plot.
+            Default is ``'inferno'``.
+        colorbar_shrink: float, optional
+            The shrink parameter of the colorbar. This can be needed if the plot is
+            included as a subplot to adjust the size of the colorbar.
+            Default is ``1``, meaning original scale.
         marker_size : float | None, optional
             The size of the scatter markers in points**2.
             Default is ``None``, meaning the default value supplied by

--- a/pyvisgrid/plotting/plotting.py
+++ b/pyvisgrid/plotting/plotting.py
@@ -41,7 +41,7 @@ def _configure_axes(
         raise KeyError("The parameters ax and fig have to be both None or not None!")
 
     if ax is None:
-        fig, ax = plt.subplots(layout="constrained", **fig_args)
+        fig, ax = plt.subplots(layout="tight", **fig_args)
 
     return fig, ax
 
@@ -117,9 +117,11 @@ def plot_ungridded_uv(
     gridder,
     mode: str = "wave",
     show_times: bool = True,
+    use_relative_time: bool = True,
     time_cmap: str | matplotlib.colors.Colormap = "inferno",
     colorbar_shrink: float = 1.0,
     marker_size: float | None = None,
+    aspect_args: dict | None = None,
     plot_args: dict = None,
     fig_args: dict = None,
     save_to: str | None = None,
@@ -139,6 +141,13 @@ def plot_ungridded_uv(
         plotted in units of the reference wavelength, or ``meter``,
         meaning the (u,v) coordinates will be plotted in meter.
         Default is ``wave``.
+    show_times : bool, optional
+        Whether to show the timestamps of the measured visibilities
+        as a colormap. Default is ``True``.
+    use_relative_time : bool, optional
+        Whether to show the times relative to the timestamp of the
+        first measurement in hours.
+        Default is ``True``.
     times_cmap: str | matplotlib.colors.Colormap, optional
         The colormap to be used for the time component of the plot.
         Default is ``'inferno'``.
@@ -189,12 +198,15 @@ def plot_ungridded_uv(
     if save_args is None:
         save_args = dict(bbox_inches="tight")
 
+    if aspect_args is None:
+        aspect_args = dict(aspect="equal", adjustable="box")
+
     fig, ax = _configure_axes(fig=fig, ax=ax, fig_args=fig_args)
 
     match mode:
         case "wave":
             u, v = gridder.u_wave, gridder.v_wave
-            unit = "$1/\\lambda$"
+            unit = "$\\lambda$"
         case "meter":
             u, v = gridder.u_meter, gridder.v_meter
             unit = "m"
@@ -203,22 +215,30 @@ def plot_ungridded_uv(
                 "The given mode does not exist! Valid modes are: wave, meter."
             )
 
+    times = np.tile(gridder.times.mjd, reps=2) if show_times else None
+    time_unit = "MJD"
+
+    if use_relative_time and show_times:
+        times -= times[0] * 24
+        time_unit = "h"
+
     scat = ax.scatter(
         x=np.append(-u, u),
         y=np.append(-v, v),
-        c=np.tile(gridder.times, reps=2) if show_times else None,
+        c=times,
         s=marker_size,
         cmap=time_cmap if show_times else None,
         **plot_args,
     )
 
     if show_times:
-        fig.colorbar(scat, ax=ax, shrink=colorbar_shrink, label="Times in MJD")
+        fig.colorbar(scat, ax=ax, shrink=colorbar_shrink, label="Time / " + time_unit)
 
-    ax.set_aspect("equal", "box")
+    ax.set_aspect(**aspect_args)
+    scat.set_rasterized(True)
 
-    ax.set_xlabel(f"$u$ in {unit}")
-    ax.set_ylabel(f"$v$ in {unit}")
+    ax.set_xlabel(f"$u$ / {unit}")
+    ax.set_ylabel(f"$v$ / {unit}")
 
     if save_to is not None:
         fig.savefig(save_to, **save_args)
@@ -374,7 +394,7 @@ def plot_mask(
                 **plot_args,
             )
             fig.colorbar(
-                im, ax=ax, shrink=colorbar_shrink, label="$(u,v)$ per frequel in 1/fq"
+                im, ax=ax, shrink=colorbar_shrink, label="$(u,v)$ per frequel / 1/fq"
             )
         case "abs":
             mask_abs, _ = grid_data.get_mask_abs_phase()
@@ -386,7 +406,7 @@ def plot_mask(
                 cmap=cmap,
                 **plot_args,
             )
-            fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Amplitude in a.u.")
+            fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Amplitude / a.u.")
         case "phase":
             _, mask_phase = grid_data.get_mask_abs_phase()
             im = ax.imshow(
@@ -397,7 +417,7 @@ def plot_mask(
                 cmap=cmap,
                 **plot_args,
             )
-            cbar = fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Phase in rad")
+            cbar = fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Phase / rad")
 
             cbar.set_ticks(np.arange(-np.pi, 3 / 2 * np.pi, np.pi / 2))
             cbar.set_ticklabels(["$-\\pi$", "$-\\pi/2$", "$0$", "$\\pi/2$", "$\\pi$"])
@@ -410,7 +430,7 @@ def plot_mask(
                 cmap=cmap,
                 **plot_args,
             )
-            fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Real Part in a.u.")
+            fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Real Part / a.u.")
         case "imag":
             im = ax.imshow(
                 grid_data.mask_imag,
@@ -421,7 +441,7 @@ def plot_mask(
                 **plot_args,
             )
             fig.colorbar(
-                im, ax=ax, shrink=colorbar_shrink, label="Imaginary Part in a.u."
+                im, ax=ax, shrink=colorbar_shrink, label="Imaginary Part / a.u."
             )
         case _:
             raise ValueError(
@@ -586,19 +606,19 @@ def plot_dirty_image(
         cell_size = grid_data.fov / img_size
 
         extent = (
-            np.array([-img_size / 2, img_size / 2] * 2) * cell_size * units.arcsecond
+            np.array([-img_size / 2, img_size / 2] * 2) * cell_size * units.rad
         ).to(unit)
 
         if center_pos is not None:
-            center_pos = np.array(center_pos) * unit
+            center_pos = (np.array(center_pos) * units.degree).to(unit)
             extent[:2] += center_pos[0]
             extent[2:] += center_pos[1]
             label_prefix = ""
         else:
             label_prefix = "Relative "
 
-        ax.set_xlabel(f"{label_prefix}RA in {unit}")
-        ax.set_ylabel(f"{label_prefix}DEC in {unit}")
+        ax.set_xlabel(f"{label_prefix}RA / {unit}")
+        ax.set_ylabel(f"{label_prefix}DEC / {unit}")
 
         extent = extent.value
 
@@ -623,7 +643,8 @@ def plot_dirty_image(
         extent=extent,
         **plot_args,
     )
-    fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Flux Density in Jy/px")
+
+    fig.colorbar(im, ax=ax, shrink=colorbar_shrink, label="Flux Density / Jy/pix")
 
     if save_to is not None:
         fig.savefig(save_to, **save_args)

--- a/pyvisgrid/plotting/plotting.py
+++ b/pyvisgrid/plotting/plotting.py
@@ -116,6 +116,9 @@ def _apply_crop(ax: matplotlib.axes.Axes, crop: tuple[list[float | None]]):
 def plot_ungridded_uv(
     gridder,
     mode: str = "wave",
+    show_times: bool = True,
+    time_cmap: str | matplotlib.colors.Colormap = "inferno",
+    colorbar_shrink: float = 1.0,
     marker_size: float | None = None,
     plot_args: dict = None,
     fig_args: dict = None,
@@ -136,6 +139,13 @@ def plot_ungridded_uv(
         plotted in units of the reference wavelength, or ``meter``,
         meaning the (u,v) coordinates will be plotted in meter.
         Default is ``wave``.
+    times_cmap: str | matplotlib.colors.Colormap, optional
+        The colormap to be used for the time component of the plot.
+        Default is ``'inferno'``.
+    colorbar_shrink: float, optional
+        The shrink parameter of the colorbar. This can be needed if the plot is
+        included as a subplot to adjust the size of the colorbar.
+        Default is ``1``, meaning original scale.
     marker_size : float | None, optional
         The size of the scatter markers in points**2.
         Default is ``None``, meaning the default value supplied by
@@ -171,7 +181,7 @@ def plot_ungridded_uv(
         The axes object.
     """
     if plot_args is None:
-        plot_args = dict(color="royalblue")
+        plot_args = dict(color="royalblue") if not show_times else dict()
 
     if fig_args is None:
         fig_args = {}
@@ -193,7 +203,17 @@ def plot_ungridded_uv(
                 "The given mode does not exist! Valid modes are: wave, meter."
             )
 
-    ax.scatter(x=np.append(-u, u), y=np.append(-v, v), s=marker_size, **plot_args)
+    scat = ax.scatter(
+        x=np.append(-u, u),
+        y=np.append(-v, v),
+        c=np.tile(gridder.times, reps=2) if show_times else None,
+        s=marker_size,
+        cmap=time_cmap if show_times else None,
+        **plot_args,
+    )
+
+    if show_times:
+        fig.colorbar(scat, ax=ax, shrink=colorbar_shrink, label="Times in MJD")
 
     ax.set_aspect("equal", "box")
 
@@ -427,7 +447,7 @@ def plot_dirty_image(
     center_pos: tuple[float] | None = None,
     norm: str | matplotlib.colors.Normalize = None,
     colorbar_shrink: float = 1,
-    cmap: str | matplotlib.colors.Colormap | None = "inferno",
+    cmap: str | matplotlib.colors.Colormap = "inferno",
     plot_args: dict = None,
     fig_args: dict = None,
     save_to: str | None = None,
@@ -501,10 +521,9 @@ def plot_dirty_image(
         The shrink parameter of the colorbar. This can be needed if the plot is
         included as a subplot to adjust the size of the colorbar.
         Default is ``1``, meaning original scale.
-    cmap: str | matplotlib.colors.Colormap | None, optional
+    cmap: str | matplotlib.colors.Colormap, optional
         The colormap to be used for the plot.
-        Default is ``None``, meaning the colormap will be default to a value
-        fitting for the chosen mode.
+        Default is ``'inferno'``.
     plot_args : dict, optional
         The additional arguments passed to the scatter plot.
         Default is ``{"color":"royalblue"}``.


### PR DESCRIPTION
- Added a `times` argument to the `Gridder` class and ensured it is properly set from all data sources (`from_pyvisgen`, `from_fits`, and `from_ms` methods). Times are now handled as MJD using `astropy.time.Time`, enabling temporal analysis of visibilities.

- Switched from `casatools.table` to `casacore.tables.table` for MS file access, improved selection and masking logic, and now correctly extracts time and frequency information per baseline. Flagging and data selection logic were made more robust.

- The `plot_ungridded_uv` function now supports visualizing timestamps as a colormap, with options for relative time, colormap selection, and colorbar scaling. The plotting API and docstrings were updated to reflect these new options.


- Improved axis and colorbar labeling across plotting functions for consistency, using slashes instead of "in" for units, and standardized colormap labels. 