### PR TITLE
Move if clause out of np.tile

### DIFF
--- a/docs/changes/39.bugfix.rst
+++ b/docs/changes/39.bugfix.rst
@@ -1,0 +1,1 @@
+- Fixes ``ValueError`` and ensures that the ``Time`` object is only created when ``show_times`` is ``True``.

--- a/src/pyvisgrid/plotting/plotting.py
+++ b/src/pyvisgrid/plotting/plotting.py
@@ -218,8 +218,8 @@ def plot_ungridded_uv(
                 "The given mode does not exist! Valid modes are: wave, meter."
             )
 
-    times = Time(
-        np.tile(gridder.times.mjd, reps=2) if show_times else None, format="mjd"
+    times = (
+        Time(np.tile(gridder.times.mjd, reps=2), format="mjd") if show_times else None
     )
     time_unit = "MJD"
 


### PR DESCRIPTION
- Fixes `ValueError` and ensures that the `Time` object is only created when `show_times` is `True`.