### PR TITLE
Add uvh5 support

### DIFF
--- a/docs/changes/64.bugfix.rst
+++ b/docs/changes/64.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where the dimensions of the visibility data were not checked correctly. This had allowed data with wrong dimensions to pass the check.

--- a/docs/changes/64.feature.rst
+++ b/docs/changes/64.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`pyvisgrid.core.gridder.Gridder.from_uvh5` to the Gridder class. This method allows gridding from `uvh5` files as implemented in pyvisgen. The keyword argument `station_ids_unavail` allows reducing the active antennas, thus reducing the operational capacity of the array without the need for full simulation rerun.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,6 +181,7 @@ intersphinx_mapping = {
     "rich": ("https://rich.readthedocs.io/en/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
+    "pyvisgen": ("https://pyvisgen.readthedocs.io/en/latest/", None),
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ tests = [
   "h5py>=3.14.0",
   "pytest >= 7.0",
   "pytest-cov>=6.2.1",
+  "pytest-mock>=3.15.1",
   "pytest-order>=1.3.0",
   "pytest-xdist>=3.8.0",
   "restructuredtext-lint>=1.4.0",

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -438,8 +438,8 @@ class Gridder:
                         [vis_data.real, vis_data.imag, np.ones(vis_data.shape)],
                         axis=3,
                     )[:, None, None, :, None, ...]
-            else:
-                raise RuntimeError("Expected vis_data to be of dimension 3 or 7")
+                else:
+                    raise RuntimeError("Expected vis_data to be of dimension 3 or 7")
 
             del V11, V22, V12, V21
 

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -300,8 +300,11 @@ class Gridder:
                     [vis_data.real, vis_data.imag, np.ones(vis_data.shape)],
                     axis=3,
                 )[:, None, None, :, None, ...]
-        else:
-            raise ValueError("Expected vis_data to be of dimension 3 or 7")
+            else:
+                raise RuntimeError(
+                    "Expected vis_data to be of dimension 3 or 7 but got"
+                    f"{vis_data.ndim}"
+                )
 
         cls = cls(
             u_meter=u_meter.cpu().numpy(),
@@ -439,7 +442,10 @@ class Gridder:
                         axis=3,
                     )[:, None, None, :, None, ...]
                 else:
-                    raise RuntimeError("Expected vis_data to be of dimension 3 or 7")
+                    raise RuntimeError(
+                        "Expected vis_data to be of dimension 3 or 7 but got"
+                        f"{vis_data.ndim}"
+                    )
 
             del V11, V22, V12, V21
 

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -398,6 +398,7 @@ class Gridder:
 
         Setting the ``station_ids_unavail`` keyword argument to a value greater ``0.0``,
         you can reduce the array, without the need to re-simulate the entire dataset:
+
         >>> gridded_vis_reduced = Gridder.from_uvh5(
         ...     "/path/to/example.uvh5",
         ...     fov=0.024,

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -344,6 +344,88 @@ class Gridder:
         return cls
 
     @classmethod
+    def from_uvh5(cls, file, fov, stokes_components="I", polarizations=None, stations_unavail=1.0):
+        rng = np.random.default_rng()
+        
+        with h5py.File(file) as hf:
+            st_ids = np.asarray(hf["uvw"]["st_id_pairs"])
+            unique_st_ids = np.unique(st_ids)
+            
+            unavail = rng.choice(unique_st_ids, size=int(len(unique_st_ids) * stations_unavail), replace=False)
+            valid = ~(np.isin(st_pairs, unavail).any(axis=1) == True)
+            
+            vis = hf["visibilities"]
+            V11 = np.asarray(vis["V_11"])[valid]
+            V22 = np.asarray(vis["V_22"])[valid]
+            V12 = np.asarray(vis["V_12"])[valid]
+            V21 = np.asarray(vis["V_21"])[valid]
+            
+            vis_data = np.permute_dims(np.concatenate(
+                [V11[None], V22[None], V12[None], V21[None]], axis=0
+            ), axes=(1, 2, 0))
+
+            if vis_data.ndim != 7:
+                if vis_data.ndim == 3:
+                    vis_data = np.stack(
+                        [vis_data.real, vis_data.imag, np.ones(vis_data.shape)],
+                        axis=3,
+                    )[:, None, None, :, None, ...]
+            else:
+                raise ValueError("Expected vis_data to be of dimension 3 or 7")
+
+            del V11, V22, V12, V21
+
+            u_meter = np.asarray(hf["uvw"]["u"])[valid]
+            v_meter = np.asarray(hf["uvw"]["v"])[valid]
+
+            img_size = hf["sky"]["SI"].shape[-1]
+
+            frequency_bands = np.asarray(hf["frequency_bands"])
+            ref_frequency = frequency_bands[0]
+            frequency_offsets = frequency_bands - ref_frequency
+
+        cls = cls(
+            u_meter=u_meter,
+            v_meter=v_meter,
+            times=-1,  # for now, uvh5 does not contain timestamps
+            img_size=img_size,
+            fov=fov,
+            ref_frequency=ref_frequency,
+            frequency_offsets=frequency_offsets,
+        )
+
+        if isinstance(stokes_components, str):
+            stokes_components = [stokes_components]
+
+        if polarizations is None:
+            polarizations = ""
+
+        if isinstance(polarizations, str):
+            polarizations = [polarizations]
+
+        if len(stokes_components) != len(polarizations):
+            raise IndexError(
+                "The length of stokes_components has to be equal "
+                "to the length of polarizations!"
+            )
+
+        for stokes_comp, polarization in zip(stokes_components, polarizations):
+            # get stokes visibilities depending on stokes component to grid
+            # and polarization mode
+            stokes_vis = get_stokes_from_vis_data(vis_data, stokes_comp, polarization)
+            try:
+                stokes_vis = stokes_vis.swapaxes(0, 1).ravel()
+            except AxisError:
+                stokes_vis = stokes_vis.ravel()
+
+            # FIXME: probably some kind of difference in normalization.
+            # Factor 2 fixes this for now. Has to be investigated.
+            stokes_vis *= 2
+            cls.stokes[stokes_comp] = GridData(vis_data=stokes_vis)
+
+        return cls
+
+    @classmethod
     def from_fits(
         cls,
         path: str,

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import h5py
 import numpy as np
 from astropy.constants import c
 from astropy.io import fits
@@ -344,25 +345,92 @@ class Gridder:
         return cls
 
     @classmethod
-    def from_uvh5(cls, file, fov, stokes_components="I", polarizations=None, stations_unavail=1.0):
+    def from_uvh5(
+        cls,
+        file: str | Path,
+        *,
+        fov: float,
+        stokes_components: str | list[str] = "I",
+        polarizations: str | list[str] | None = None,
+        station_ids_unavail: float = 0.0,
+        img_size: int | None = None,
+    ):
+        """Initializes the gridder with visibility data from the UVH5 file format.
+
+        This method allows to select stokes components that will be computed
+        for a given polarization.
+
+        Parameters
+        ----------
+        file : str or :class:`~pathlib.Path`
+            Path to the file that you want to grid. This file has to be
+            in the UVH5 file format from pyvisgen.
+        fov : float
+            The physical size of the image in asec.
+        stokes_components : str | list[str], optional
+            The Stokes components which are to be calculated and saved in the gridder.
+            This can either be a list of components (e.g. ``['I', 'V']``) or a single
+            string. Default: ``'I'``.
+        polarizations : str | list[str] | None, optional
+            The polarization type. Default: ``None``.
+        station_ids_unavail : float, optional
+            Percentage of station ids that are unavailable during the observation.
+            This allows simulating reduced operation capacity even after the main
+            simulation in pyvisgen and thus avoids having to rerun the same simulation
+            with different reduced arrays. Default: ``0.0``
+        img_size : int or None, optional
+            Image size is read from the file. In case the image size cannot be
+            read, e.g. because the sky image was not saved to the file ("file/sky/SI"),
+            or you want to grid the image to a different size, it can be set
+            through this keyword argument. Default: ``None``
+
+        Examples
+        --------
+        >>> gridded_vis = Gridder.from_uvh5(
+        ...     "/path/to/example.uvh5",
+        ...     fov=0.024,
+        ... ).grid()
+        >>> gridded_vis.vis_data.shape
+        (1344,)
+
+        Setting the ``station_ids_unavail`` keyword argument to a value greater ``0.0``,
+        you can reduce the array, without the need to re-simulate the entire dataset:
+        >>> gridded_vis_reduced = Gridder.from_uvh5(
+        ...     "/path/to/example.uvh5",
+        ...     fov=0.024,
+        ...     station_ids_unavail=0.5,
+        ... ).grid()
+        >>> gridded_vis_reduced.vis_data.shape
+        (288,)
+
+        See Also
+        --------
+        :class:`~pyvisgen.io.datawriters.UVH5Writer` : The `UVH5` data writer
+            class as implemented in :mod:`pyvisgen`, outlining the file structure.
+        """
         rng = np.random.default_rng()
-        
+
         with h5py.File(file) as hf:
             st_ids = np.asarray(hf["uvw"]["st_id_pairs"])
             unique_st_ids = np.unique(st_ids)
-            
-            unavail = rng.choice(unique_st_ids, size=int(len(unique_st_ids) * stations_unavail), replace=False)
-            valid = ~(np.isin(st_pairs, unavail).any(axis=1) == True)
-            
+
+            unavail = rng.choice(
+                unique_st_ids,
+                size=int(len(unique_st_ids) * station_ids_unavail),
+                replace=False,
+            )
+            valid = not np.isin(st_ids, unavail).any(axis=1)
+
             vis = hf["visibilities"]
             V11 = np.asarray(vis["V_11"])[valid]
             V22 = np.asarray(vis["V_22"])[valid]
             V12 = np.asarray(vis["V_12"])[valid]
             V21 = np.asarray(vis["V_21"])[valid]
-            
-            vis_data = np.permute_dims(np.concatenate(
-                [V11[None], V22[None], V12[None], V21[None]], axis=0
-            ), axes=(1, 2, 0))
+
+            vis_data = np.permute_dims(
+                np.concatenate([V11[None], V22[None], V12[None], V21[None]], axis=0),
+                axes=(1, 2, 0),
+            )
 
             if vis_data.ndim != 7:
                 if vis_data.ndim == 3:
@@ -371,14 +439,21 @@ class Gridder:
                         axis=3,
                     )[:, None, None, :, None, ...]
             else:
-                raise ValueError("Expected vis_data to be of dimension 3 or 7")
+                raise RuntimeError("Expected vis_data to be of dimension 3 or 7")
 
             del V11, V22, V12, V21
 
             u_meter = np.asarray(hf["uvw"]["u"])[valid]
             v_meter = np.asarray(hf["uvw"]["v"])[valid]
 
-            img_size = hf["sky"]["SI"].shape[-1]
+            if not img_size:
+                try:
+                    img_size = hf["sky"]["SI"].shape[-1]
+                except KeyError as e:
+                    raise RuntimeError(
+                        f"'img_size' could not be read from {file}. Please use the "
+                        "'img_size' keyword argument instead."
+                    ) from e
 
             frequency_bands = np.asarray(hf["frequency_bands"])
             ref_frequency = frequency_bands[0]
@@ -387,7 +462,7 @@ class Gridder:
         cls = cls(
             u_meter=u_meter,
             v_meter=v_meter,
-            times=-1,  # for now, uvh5 does not contain timestamps
+            times=-1,  # NOTE: For now, uvh5 does not contain timestamps, may be changed
             img_size=img_size,
             fov=fov,
             ref_frequency=ref_frequency,

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -423,13 +423,13 @@ class Gridder:
                 size=int(len(unique_st_ids) * station_ids_unavail),
                 replace=False,
             )
-            valid = ~np.isin(st_ids, unavail).any(axis=1)
+            avail = ~np.isin(st_ids, unavail).any(axis=1)
 
             vis = hf["visibilities"]
-            V11 = np.asarray(vis["V_11"])[valid]
-            V22 = np.asarray(vis["V_22"])[valid]
-            V12 = np.asarray(vis["V_12"])[valid]
-            V21 = np.asarray(vis["V_21"])[valid]
+            V11 = np.asarray(vis["V_11"])[avail]
+            V22 = np.asarray(vis["V_22"])[avail]
+            V12 = np.asarray(vis["V_12"])[avail]
+            V21 = np.asarray(vis["V_21"])[avail]
 
             vis_data = np.permute_dims(
                 np.concatenate([V11[None], V22[None], V12[None], V21[None]], axis=0),
@@ -450,8 +450,10 @@ class Gridder:
 
             del V11, V22, V12, V21
 
-            u_meter = np.asarray(hf["uvw"]["u"])[valid]
-            v_meter = np.asarray(hf["uvw"]["v"])[valid]
+            u_meter = np.asarray(hf["uvw"]["u"])[avail]
+            v_meter = np.asarray(hf["uvw"]["v"])[avail]
+
+            times = np.asarray(hf["times"])[avail]
 
             if not img_size:
                 try:
@@ -469,7 +471,7 @@ class Gridder:
         cls = cls(
             u_meter=u_meter,
             v_meter=v_meter,
-            times=-1,  # NOTE: For now, uvh5 does not contain timestamps, may be changed
+            times=times,
             img_size=img_size,
             fov=fov,
             ref_frequency=ref_frequency,
@@ -500,9 +502,6 @@ class Gridder:
             except AxisError:
                 stokes_vis = stokes_vis.ravel()
 
-            # FIXME: probably some kind of difference in normalization.
-            # Factor 2 fixes this for now. Has to be investigated.
-            stokes_vis *= 2
             cls.stokes[stokes_comp] = GridData(vis_data=stokes_vis)
 
         return cls

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -419,7 +419,7 @@ class Gridder:
                 size=int(len(unique_st_ids) * station_ids_unavail),
                 replace=False,
             )
-            valid = not np.isin(st_ids, unavail).any(axis=1)
+            valid = ~np.isin(st_ids, unavail).any(axis=1)
 
             vis = hf["visibilities"]
             V11 = np.asarray(vis["V_11"])[valid]

--- a/src/pyvisgrid/core/gridder.py
+++ b/src/pyvisgrid/core/gridder.py
@@ -407,6 +407,12 @@ class Gridder:
         >>> gridded_vis_reduced.vis_data.shape
         (288,)
 
+        Note that this only disables a randomized selection of antennas for the
+        entire observation. Depending on the visibility of the source, the data taken
+        by the antennas may vary during measurement, and the resulting visibilites
+        dataset may be smaller or larger than expected (see, e.g., the shapes
+        ``(1344,)`` vs ``(288,)`` although only half of the antennas were unavailable).
+
         See Also
         --------
         :class:`~pyvisgen.io.datawriters.UVH5Writer` : The `UVH5` data writer

--- a/tests/test_uvh5_gridding.py
+++ b/tests/test_uvh5_gridding.py
@@ -36,6 +36,8 @@ def mock_data(tmp_path) -> Path:
         freq_bands = np.array([15e9])
         f.create_dataset("frequency_bands", data=freq_bands)
 
+        f.create_dataset("times", data=np.arange(100))
+
         sky_grp = f.create_group("sky")
         sky_grp.create_dataset("SI", data=rng.random((64, 64)))
 
@@ -64,6 +66,8 @@ def mock_data_no_sky(tmp_path) -> Path:
 
         freq_bands = np.array([15e9])
         f.create_dataset("frequency_bands", data=freq_bands)
+
+        f.create_dataset("times", data=np.arange(100))
 
     return output_file
 

--- a/tests/test_uvh5_gridding.py
+++ b/tests/test_uvh5_gridding.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from pyvisgrid import Gridder
+
+def random_data(rng, size=100, cmplx=True):
+    if cmplx:
+        return (rng.random(size) + 1j * rng.random(size)).reshape(-1, 1)
+
+    return rng.random(size)
+
+@pytest.fixture
+def mock_data(tmp_path) -> Path:
+    rng = np.random.default_rng(42)
+
+    output_file: Path = tmp_path / "test_data.uvh5"
+
+    with h5py.File(output_file, "w") as f:
+        vis_grp = f.create_group("visibilities")
+        vis_grp.create_dataset("V_11", data=random_data(rng))
+        vis_grp.create_dataset("V_22", data=random_data(rng))
+        vis_grp.create_dataset("V_12", data=random_data(rng))
+        vis_grp.create_dataset("V_21", data=random_data(rng))
+
+        uvw_grp = f.create_group("uvw")
+        uvw_grp.create_dataset("u", data=random_data(rng, cmplx=False))
+        uvw_grp.create_dataset("v", data=random_data(rng, cmplx=False))
+        uvw_grp.create_dataset(
+            "st_id_pairs",
+            data=np.array(np.meshgrid(np.arange(10), np.arange(10))).T.reshape(-1,2)
+        )
+
+        freq_bands = np.array([15e9])
+        f.create_dataset("frequency_bands", data=freq_bands)
+
+        sky_grp = f.create_group("sky")
+        sky_grp.create_dataset("SI", data=rng.random((64, 64)))
+
+    return output_file
+
+@pytest.fixture
+def mock_data_no_sky(tmp_path) -> Path:
+    rng = np.random.default_rng(42)
+
+    output_file: Path = tmp_path / "test_data.uvh5"
+
+    with h5py.File(output_file, "w") as f:
+        vis_grp = f.create_group("visibilities")
+        vis_grp.create_dataset("V_11", data=random_data(rng))
+        vis_grp.create_dataset("V_22", data=random_data(rng))
+        vis_grp.create_dataset("V_12", data=random_data(rng))
+        vis_grp.create_dataset("V_21", data=random_data(rng))
+
+        uvw_grp = f.create_group("uvw")
+        uvw_grp.create_dataset("u", data=random_data(rng, cmplx=False))
+        uvw_grp.create_dataset("v", data=random_data(rng, cmplx=False))
+        uvw_grp.create_dataset(
+            "st_id_pairs",
+            data=np.array(np.meshgrid(np.arange(10), np.arange(10))).T.reshape(-1,2)
+        )
+
+        freq_bands = np.array([15e9])
+        f.create_dataset("frequency_bands", data=freq_bands)
+
+    return output_file
+
+
+class TestUVH5Gridding:
+    @pytest.mark.parametrize(
+        "fov", ([0.024, 0.1, 10, 100])
+    )
+    def test_defaults(self, fov, mock_data) -> None:
+        file = mock_data
+
+        gridder = Gridder.from_uvh5(file, fov=fov)
+        gridder.grid("I")
+
+        assert len(gridder["I"].vis_data) == 100
+        assert gridder["I"].mask is not None
+        assert gridder["I"].mask_real is not None
+        assert gridder["I"].mask_imag is not None
+        assert gridder["I"].dirty_image is not None
+
+
+    @pytest.mark.parametrize(
+        "img_size", ([64, 128, 256, 512])
+    )
+    def test_img_size(self, img_size, mock_data) -> None:
+        file = mock_data
+
+        gridder = Gridder.from_uvh5(file, fov=0.024, img_size=img_size)
+        gridder.grid("I")
+
+        assert gridder["I"].mask is not None
+        assert gridder["I"].mask_real is not None
+        assert gridder["I"].mask_imag is not None
+        assert gridder["I"].dirty_image is not None
+        assert gridder["I"].dirty_image.shape == (img_size, img_size)
+
+    @pytest.mark.parametrize(
+        "vis_shape",
+        (
+            [
+                100,
+                (100, 1),
+                (100, 1, 1, 1),
+                (100, 1, 1, 1, 1, 1, 1, 1)
+            ]
+        )
+    )
+    def test_raises_vis_shape(self, vis_shape,mock_data, mocker) -> None:
+        rng = np.random.default_rng(42)
+        file = mock_data
+
+        mock_np_permute_dims= mocker.patch(
+            "pyvisgrid.core.gridder.np.permute_dims",
+            return_value=rng.random(vis_shape),
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            gridder = Gridder.from_uvh5(file, fov=0.024)
+
+        assert "Expected vis_data to be of dimension 3 or 7" in str(excinfo.value)
+
+
+    def test_raises_img_size(self, mock_data_no_sky) -> None:
+        file = mock_data_no_sky
+
+        with pytest.raises(RuntimeError) as excinfo:
+            gridder = Gridder.from_uvh5(file, fov=0.024)
+
+        assert f"'img_size' could not be read from {file}" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "station_ids_unavail", ([0.1, 0.5, 0.75, 0.9])
+    )
+    def test_reduce_array(self, station_ids_unavail, mock_data) -> None:
+        file = mock_data
+
+        full_gridder = Gridder.from_uvh5(
+            file,
+            fov=0.024,
+            station_ids_unavail=0.0
+        )
+        full_gridder.grid("I")
+
+        gridder = Gridder.from_uvh5(
+            file,
+            fov=0.024,
+            station_ids_unavail=station_ids_unavail
+        )
+        gridder.grid("I")
+
+        assert gridder["I"].mask is not None
+        assert gridder["I"].mask_real is not None
+        assert gridder["I"].mask_imag is not None
+        assert gridder["I"].dirty_image is not None
+
+        assert len(gridder["I"].vis_data) < len(full_gridder["I"].vis_data)
+
+

--- a/tests/test_uvh5_gridding.py
+++ b/tests/test_uvh5_gridding.py
@@ -160,5 +160,3 @@ class TestUVH5Gridding:
         assert gridder["I"].dirty_image is not None
 
         assert len(gridder["I"].vis_data) < len(full_gridder["I"].vis_data)
-
-


### PR DESCRIPTION
Adds `uvh5` file support for the main gridding class. Due to the file structure specified in `pyvisgen`, the new `from_uvh5` method allows users to randomly remove station ids from the array, thus simulating reduced operational capacity without the need ro rerun the entire simulation in `pyvisgen` for reduced arrays.

Merge after https://github.com/radionets-project/pyvisgen/pull/153.